### PR TITLE
Angular-friendly HAML

### DIFF
--- a/Syntaxes/Ruby Haml.tmLanguage
+++ b/Syntaxes/Ruby Haml.tmLanguage
@@ -115,7 +115,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^\s*(?:((%)([\w:]+))|(?=\.|#[^\{]))</string>
+			<string>^\s*(?:((%)([\w:-]+))|(?=\.|#[^\{]))</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -154,7 +154,7 @@
 					<key>begin</key>
 					<string>\{(?=.*\}|.*\|\s*$)</string>
 					<key>end</key>
-					<string>\}|$|^(?!.*\|\s*$)</string>
+					<string>\}(?!,)|$|^(?!.*\|\s*$)</string>
 					<key>name</key>
 					<string>meta.section.attributes.haml</string>
 					<key>patterns</key>


### PR DESCRIPTION
- Permit dashes in element names, since HAML does (for tags like `%ng-form`).
- Don't match braces followed by commas when ending the attributes capture. Previously, `{ ng: { foo: true }, data: { bar: true } }` would stop matching at the first closing brace, not the last; it's slightly greedier now.
